### PR TITLE
explicitly specify that the last.fm time/date is in UTC

### DIFF
--- a/lastfm-recenttracks
+++ b/lastfm-recenttracks
@@ -117,7 +117,7 @@ function parseRecentTracksXml($rss) {
  *   The rendered date.
  */
 function formatDate($date) {
-  $phpDate = strtotime($date);
+  $phpDate = strtotime($date . "UTC");
   $formattedDate = strftime("%Y-%m-%d %H:%M", $phpDate);
   return $formattedDate;
 }


### PR DESCRIPTION
so that local timezone conversion will occur properly?   otherwise we're all zulu :(
